### PR TITLE
v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 1.32.0
+
+- Add _fallback image_ if initial _src_ fails in `Image`
+- Update `Button.Link` to use _color_ as colors.MAIN.INFO
+- Align `Input` _icon_ vertically and increase _line-height_ for title-2
+- Add _itemProps_ and _Tag.Meta_ for `Column`, `Pricing` and `OrderItem`
+- Add _titleProps_ and _descriptionProps_ in `Section`
+- Align `Breadcrumbs` _links_ vertically
+- Add _fallbackImage_ for prop drilling into `OrderItem` and `ImagesGallery`
+- Refactor
+  - `FlatList` to render list based on _wrapperTag_ and _itemWrapperTag_
+  - `ImagesGallery` for better SEO structure.
+- Add `useDatasets` hook to `Image` and `Typography`
+- Add _navigate_ prop in `Breadcrumbs` for using prefer navigator handler
+- Add _versioning guide_ for Readme.md
+
 # 1.31.0
 
 - Update dependencies

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # arepa-ui
 
 Free and open-source CSS framework that it called Arepa because who does not love one?
+
+## Versioning Guide
+
+- **<span style="color: red;">Major Update</span>**: - backward-incompatible updates (e.g., **<span style="color: red;">1</span>.0.0**)
+- **<span style="color: orange;">Minor Update</span>**: - backward-compatible features (e.g., **0.<span style="color: orange;">1</span>.0**)
+- **<span style="color: green;">Patch Update</span>**: - backward-compatible bug fixes (e.g., **0.0.<span style="color: green;">1</span>**)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wicadu/arepa",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Free and open-source CSS framework that it called Arepa because who does not love one?",
   "author": "wicadu Developers <help@dev.wicadu.com>",
   "exports": {

--- a/src/ui/atoms/Button.tsx
+++ b/src/ui/atoms/Button.tsx
@@ -23,7 +23,6 @@ enum ButtonType {
   link = 'link',
 }
 
-
 interface Props {
   children: React.ReactNode
   onClick?: () => void
@@ -43,9 +42,9 @@ const defaultProps: Partial<Props> = {
   type: ButtonType.primary,
   size: UIElementSizesEnum.Medium,
   htmlType: HtmlType.button,
-  onClick() { },
+  onClick() {},
   loading: false,
-  width: '100%'
+  width: '100%',
 }
 
 function Button({
@@ -57,16 +56,13 @@ function Button({
   loading,
   ...restOfProps
 }: Props) {
-
   return (
     <button {...restOfProps} type={htmlType} disabled={disabled || loading}>
       {loading ? (
-        <Spin
-          type={outlined ? type : ButtonType.ghost}
-          size={20}
-        />
-      )
-        : children}
+        <Spin type={outlined ? type : ButtonType.ghost} size={20} />
+      ) : (
+        children
+      )}
     </button>
   )
 }
@@ -86,8 +82,8 @@ const WrapperButton = styled(Button)`
     ${({ width }) => width && `width: ${width};`}
 
     ${({ size }) => {
-    if (size === UIElementSizesEnum.Small)
-      return `
+      if (size === UIElementSizesEnum.Small)
+        return `
         height: 35px;
         font-size: 12px;
         border-radius: 7px;
@@ -97,8 +93,8 @@ const WrapperButton = styled(Button)`
         }
       `
 
-    if (size === UIElementSizesEnum.Medium)
-      return `
+      if (size === UIElementSizesEnum.Medium)
+        return `
         height: 44px;
         font-size: 12px;
         border-radius: 7px;
@@ -108,8 +104,8 @@ const WrapperButton = styled(Button)`
         }
       `
 
-    if (size === UIElementSizesEnum.Large)
-      return `
+      if (size === UIElementSizesEnum.Large)
+        return `
         height: 50px;
         font-size: 18px;
 
@@ -117,18 +113,18 @@ const WrapperButton = styled(Button)`
           font-size: 20px;
         }
       `
-  }}
+    }}
 
     ${({ type, outlined, theme, margin = '5px 0', highlight }) => {
-    const { colors } = theme
+      const { colors } = theme
 
-    let style: string = `
+      let style: string = `
       ${!highlight ? '-webkit-tap-highlight-color: transparent;' : ''}
     `
 
-    if (type === ButtonType.link) {
-      style += `
-          color: ${colors.MAIN.PRIMARY};
+      if (type === ButtonType.link) {
+        style += `
+          color: ${colors.MAIN.INFO};
           background-color: ${colors.NEUTRAL.TRANSPARENT};
           font-weight: bold;
           padding: 0px;
@@ -136,52 +132,56 @@ const WrapperButton = styled(Button)`
           margin: ${margin};
         `
 
-      return style
-    }
+        return style
+      }
 
-    if (type === ButtonType.ghost) {
-      style += `
+      if (type === ButtonType.ghost) {
+        style += `
         color: ${colors.FONT.HELPER};      
-        background-color: ${outlined ? colors.NEUTRAL.TRANSPARENT : colors.NEUTRAL.SELECTED};
+        background-color: ${
+          outlined ? colors.NEUTRAL.TRANSPARENT : colors.NEUTRAL.SELECTED
+        };
         ${getBordersStyles(1, outlined, colors.NEUTRAL.SELECTED)}
       `
 
-      return style
-    }
+        return style
+      }
 
-    if (type === ButtonType.white) {
-      style += `
-          background-color: ${outlined ? colors.NEUTRAL.TRANSPARENT : colors.NEUTRAL.CARD};
+      if (type === ButtonType.white) {
+        style += `
+          background-color: ${
+            outlined ? colors.NEUTRAL.TRANSPARENT : colors.NEUTRAL.CARD
+          };
           color: ${outlined ? colors.NEUTRAL.CARD : colors.FONT.TITLE};
           font-weight: 700;
           ${getBordersStyles(1, outlined, colors.NEUTRAL.SELECTED)}
         `
 
-      return style
-    }
+        return style
+      }
 
-    const mainColor = colors.MAIN?.[String(type).toUpperCase()]
+      const mainColor = colors.MAIN?.[String(type).toUpperCase()]
 
-    style += `
+      style += `
         background-color: ${outlined ? colors.NEUTRAL.TRANSPARENT : mainColor};
         color: ${outlined ? mainColor : colors.NEUTRAL.BACKGROUND};
         ${getBordersStyles(1, outlined, mainColor)}
       `
 
-    return style
-  }}
+      return style
+    }}
 
     ${({ disabled, type, theme }) => {
-    const { colors } = theme
+      const { colors } = theme
 
-    if (disabled && type === ButtonType.link) {
-      return `
-        color: ${colors.darkGray};
+      if (disabled && type === ButtonType.link) {
+        return `
+        color: ${colors.FONT.HELPER};
       `
-    }
+      }
 
-    if (disabled) return `opacity: 0.85;`
-  }}
+      if (disabled) return `opacity: 0.85;`
+    }}
 
   ${({ styles }) => styles}
   }

--- a/src/ui/atoms/Image.tsx
+++ b/src/ui/atoms/Image.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import styled from '@emotion/styled'
 
@@ -26,6 +26,7 @@ interface Props {
 const defaultProps: Partial<Props> = {
   width: 100,
   height: 100,
+  datasets: {},
   fit: 'cover',
   imageComponent: 'img',
 }
@@ -59,6 +60,10 @@ const Image = (props: Props) => {
     if (fallback) setImageUrl(fallback)
     onError?.(e)
   }
+
+  useEffect(() => {
+    if (src) setImageUrl(src)
+  }, [src])
 
   const _PADDING_PERCENTAGE = 25
   const _DEFAULT_RADIUS = 7

--- a/src/ui/atoms/Image.tsx
+++ b/src/ui/atoms/Image.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 
 import styled from '@emotion/styled'
 
@@ -12,21 +12,21 @@ interface Props {
   height?: number | string
   rounded?: number
   fit?: 'contain' | 'cover'
-  'data-id'?: string | number
-  onClick?: React.MouseEventHandler<HTMLImageElement>
   loading?: 'eager' | 'lazy'
   itemProp?: string
-  datasets: {
+  datasets?: {
     [key: string]: string | number
   }
-  imageComponent: React.ElementType
+  fallback?: string
+  imageComponent?: React.ElementType
+  onClick?: React.MouseEventHandler<HTMLImageElement>
+  onError?: React.ReactEventHandler<HTMLImageElement>
 }
 
 const defaultProps: Partial<Props> = {
   width: 100,
   height: 100,
   fit: 'cover',
-  'data-id': null,
   imageComponent: 'img',
 }
 
@@ -39,18 +39,26 @@ const Image = (props: Props) => {
     rounded,
     backgroundColor,
     fit,
-    onClick,
     loading,
     datasets,
     itemProp,
     imageComponent,
+    fallback,
+    onClick,
+    onError,
     ...restOfProps
   } = {
     ...defaultProps,
     ...props,
   }
 
+  const [imageUrl, setImageUrl] = useState<string>(src)
   const dataAttributes = useDataset(datasets)
+
+  const onHandlerError = (e) => {
+    if (fallback) setImageUrl(fallback)
+    onError?.(e)
+  }
 
   const _PADDING_PERCENTAGE = 25
   const _DEFAULT_RADIUS = 7
@@ -81,8 +89,9 @@ const Image = (props: Props) => {
 
   return (
     <StyledImage
-      src={src}
+      src={imageUrl}
       alt={alt}
+      data-image-is-fallback={imageUrl === fallback}
       width={width}
       rounded={rounded}
       height={height}
@@ -91,6 +100,8 @@ const Image = (props: Props) => {
       backgroundColor={backgroundColor}
       loading={loading}
       itemProp={itemProp}
+      fallback={fallback}
+      onError={onHandlerError}
       {...restOfProps}
       {...dataAttributes}
     />

--- a/src/ui/atoms/Input.tsx
+++ b/src/ui/atoms/Input.tsx
@@ -169,6 +169,8 @@ const IconContainer = styled.div<{
   children: React.ReactElement
   position: IconPosition
 }>`
+  align-items: center;
+  display: flex;
   position: absolute;
   top: 50%;
   transform: translate(0, -50%);

--- a/src/ui/atoms/Typography.tsx
+++ b/src/ui/atoms/Typography.tsx
@@ -131,7 +131,7 @@ const Title2 = styled.h2<Partial<Props>>`
 
   @media screen and (min-width: 768px) {
     font-size: 38px;
-    line-height: 40px;
+    line-height: 45px;
   }
 
   ${({ styles }) => styles}

--- a/src/ui/atoms/Typography.tsx
+++ b/src/ui/atoms/Typography.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import styled from '@emotion/styled'
 import { SerializedStyles } from '@emotion/react'
+import { useDataset } from '../../hooks'
 
 enum htmlType {
   default = 'default',
@@ -33,6 +34,9 @@ interface Props {
     weight: number
     color?: string
   }
+  datasets?: {
+    [key: string]: string | number
+  }
   decoration: string
   bold?: boolean
   styles?: string | SerializedStyles
@@ -49,14 +53,17 @@ const defaultAfterStyles: Props['afterStyles'] = {
 const defaultProps: Partial<Props> = {
   type: htmlType.default,
   align: 'left',
+  datasets: {},
   afterStyles: defaultAfterStyles,
 }
 
 function Typography(props: Props) {
-  const { children, type, ...restOfProps } = {
+  const { children, type, datasets, ...restOfProps } = {
     ...defaultProps,
     ...props,
   }
+
+  const dataAttributes = useDataset(datasets)
 
   const Component = useMemo(() => {
     if (type === htmlType.title) return Title
@@ -72,7 +79,7 @@ function Typography(props: Props) {
   }, [type])
 
   return (
-    <Component type={type} {...restOfProps}>
+    <Component type={type} {...dataAttributes} {...restOfProps}>
       {children}
     </Component>
   )

--- a/src/ui/layout/Column.tsx
+++ b/src/ui/layout/Column.tsx
@@ -5,13 +5,16 @@ import { SerializedStyles } from '@emotion/react'
 type ItemsAlign = 'top' | 'center' | 'bottom' | 'space-between'
 
 interface Props {
-  children: React.ReactNode
+  children?: React.ReactNode
   align?: ItemsAlign
   gap: number
   onClick?: () => void
   flex?: number
   styles?: string | SerializedStyles
   className?: string
+  itemProp?: string
+  itemScope?: boolean
+  itemType?: string
   forwardedRef?: React.Ref<HTMLDivElement>
 }
 
@@ -29,6 +32,9 @@ function Column(props: Props) {
     flex,
     styles,
     className,
+    itemProp,
+    itemScope,
+    itemType,
     forwardedRef,
     onClick,
   } = {
@@ -44,6 +50,9 @@ function Column(props: Props) {
       flex={flex}
       onClick={onClick}
       className={className}
+      itemProp={itemProp}
+      itemScope={itemScope}
+      itemType={itemType}
       styles={styles}
     >
       {children}

--- a/src/ui/layout/Section.tsx
+++ b/src/ui/layout/Section.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, ReactElement } from 'react'
 import { SerializedStyles, css } from '@emotion/react'
 
-import Typography from '../atoms/Typography'
+import Typography, { TypographyProps } from '../atoms/Typography'
 import Button from '../atoms/Button'
 import Row from './Row'
 
@@ -18,8 +18,10 @@ interface Props {
   children: ReactNode | ReactElement | ReactElement[]
   title: string | ReactElement
   titleAfterStyles?: AfterStyles
+  titleProps?: TypographyProps
   description?: string
   descriptionAfterStyles?: AfterStyles
+  descriptionProps?: TypographyProps
   rightChild?: string | ReactElement
   className?: string
   styles?: SerializedStyles | string
@@ -27,11 +29,13 @@ interface Props {
 }
 
 const defaultProps: Partial<Props> = {
-  title: '',
+  title: null,
   titleHtmlType: 'title-3',
   titleAfterStyles: {} as AfterStyles,
+  titleProps: {} as TypographyProps,
   description: '',
   descriptionAfterStyles: {} as AfterStyles,
+  descriptionProps: {} as TypographyProps,
   rightChild: null,
   children: null,
   className: '',
@@ -43,12 +47,14 @@ function Section(props: Props) {
     title,
     titleHtmlType,
     titleAfterStyles,
+    titleProps,
     description,
     descriptionAfterStyles,
     rightChild,
     children,
     className,
     styles,
+    descriptionProps,
   } = {
     ...defaultProps,
     ...props,
@@ -67,6 +73,7 @@ function Section(props: Props) {
               size={20}
               children={title}
               afterStyles={titleAfterStyles}
+              {...titleProps}
             />
           ) : (
             title
@@ -79,6 +86,7 @@ function Section(props: Props) {
           styles={cssDescriptionStyles}
           lineHeight={25}
           afterStyles={descriptionAfterStyles}
+          {...descriptionProps}
         >
           {description}
         </Typography>

--- a/src/ui/layout/Section.tsx
+++ b/src/ui/layout/Section.tsx
@@ -73,6 +73,7 @@ function Section(props: Props) {
               size={20}
               children={title}
               afterStyles={titleAfterStyles}
+              data-title
               {...titleProps}
             />
           ) : (
@@ -86,6 +87,7 @@ function Section(props: Props) {
           styles={cssDescriptionStyles}
           lineHeight={25}
           afterStyles={descriptionAfterStyles}
+          data-description
           {...descriptionProps}
         >
           {description}

--- a/src/ui/molecules/Breadcrumbs.tsx
+++ b/src/ui/molecules/Breadcrumbs.tsx
@@ -26,37 +26,36 @@ const defaultProps: Partial<Props> = {
   routes: [],
   segmentDelimiter: '-',
   offset: 0,
-  limit: undefined
+  limit: undefined,
 }
 
 function Breadcrumbs(props: Props) {
   const { routes, names, offset, limit, segmentDelimiter } = {
     ...defaultProps,
-    ...props
+    ...props,
   }
 
   const { pathname } = useLocation() || {}
 
-  const defaultRoutes: Route[] = useMemo(() =>
-    pathname
-      ?.split('/')
-      ?.filter((segments: string) => segments?.length > 0)
-      ?.slice(offset, limit)
-      ?.map((path: string) => ({
-        path: `${pathname?.split(path)?.[0]}${path}`,
-        name: capitalize(names?.[path] || path?.replace(segmentDelimiter, ' '))
-      })), [
-    pathname,
-    names,
-    offset,
-    limit,
-  ])
+  const defaultRoutes: Route[] = useMemo(
+    () =>
+      pathname
+        ?.split('/')
+        ?.filter((segments: string) => segments?.length > 0)
+        ?.slice(offset, limit)
+        ?.map((path: string) => ({
+          path: `${pathname?.split(path)?.[0]}${path}`,
+          name: capitalize(
+            names?.[path] || path?.replace(segmentDelimiter, ' ')
+          ),
+        })),
+    [pathname, names, offset, limit]
+  )
 
-  const routesToRender: Route[] = useMemo(() =>
-    routes?.length > 0 ? routes : defaultRoutes, [
-    routes,
-    defaultRoutes
-  ])
+  const routesToRender: Route[] = useMemo(
+    () => (routes?.length > 0 ? routes : defaultRoutes),
+    [routes, defaultRoutes]
+  )
 
   const navigateTo = (path: string) => {
     if (pathname === path) return
@@ -70,11 +69,11 @@ function Breadcrumbs(props: Props) {
           <Typography
             size={11}
             lineHeight={11}
-            type='description'
+            type="description"
             children={name}
             styles={cssItemStyles}
           />
-          <Icon name='arrow_forward_ios' size={8} />
+          <Icon name="arrow_forward_ios" size={8} />
         </Row>
       ))}
     </Container>
@@ -89,6 +88,9 @@ const Container = styled.nav`
 
 const cssItemStyles = css`
   cursor: pointer;
+  min-height: 15px;
+  align-items: center;
+  display: flex;
 
   @media screen and (min-width: 768px) {
     font-size: 13px !important;

--- a/src/ui/molecules/Breadcrumbs.tsx
+++ b/src/ui/molecules/Breadcrumbs.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo } from 'react'
 
 import styled from '@emotion/styled'
-import { navigate, useLocation } from '@reach/router'
 import { css } from '@emotion/react'
 
-import { capitalize } from '../../utils'
+import { capitalize, isBrowser } from '../../utils'
 import Icon from '../atoms/Icon'
 import Row from '../layout/Row'
 import Typography from '../atoms/Typography'
@@ -20,6 +19,7 @@ interface Props {
   segmentDelimiter?: string
   offset?: number
   limit?: number
+  navigate: (to: string, params?: Record<string, unknown>) => void
 }
 
 const defaultProps: Partial<Props> = {
@@ -27,15 +27,18 @@ const defaultProps: Partial<Props> = {
   segmentDelimiter: '-',
   offset: 0,
   limit: undefined,
+  navigate(to: string) {
+    window.location.href = to
+  },
 }
 
 function Breadcrumbs(props: Props) {
-  const { routes, names, offset, limit, segmentDelimiter } = {
+  const { routes, names, offset, limit, segmentDelimiter, navigate } = {
     ...defaultProps,
     ...props,
   }
 
-  const { pathname } = useLocation() || {}
+  const pathname: string = isBrowser() ? window?.location?.pathname : ''
 
   const defaultRoutes: Route[] = useMemo(
     () =>

--- a/src/ui/molecules/Pricing.tsx
+++ b/src/ui/molecules/Pricing.tsx
@@ -45,10 +45,11 @@ function Pricing(props: Props) {
 
   return (
     <Typography
-      {...restOfProps}
       color={color}
       size={size}
       weight={weight}
+      itemProp="price"
+      {...restOfProps}
       afterStyles={{
         color,
         content: fCurrencySign,
@@ -57,6 +58,7 @@ function Pricing(props: Props) {
       }}
     >
       <meta itemProp="priceCurrency" content={currencyCode} />
+      <meta itemProp="price" content={amount} />
 
       {isNegativeValue ? `-${value}` : value || '$?'}
     </Typography>

--- a/src/ui/organisms/OrderItem/OrderItem.tsx
+++ b/src/ui/organisms/OrderItem/OrderItem.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+
 import styled from '@emotion/styled'
 import { css, SerializedStyles } from '@emotion/react'
 
@@ -23,6 +24,8 @@ interface Props {
   description: string
   customSpecComponent?: React.ReactElement
   specs?: Spec[]
+  imageLoadingType?: 'eager' | 'lazy'
+  fallbackImage?: string
   containerStyles?: SerializedStyles | string
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void
 }
@@ -32,6 +35,8 @@ const defaultProps: Props = {
   name: '',
   description: '',
   specs: [],
+  fallbackImage: '',
+  imageLoadingType: 'eager',
 }
 
 function OrderItem(props: Props) {
@@ -43,71 +48,88 @@ function OrderItem(props: Props) {
     customSpecComponent,
     onClick,
     description,
-    containerStyles
+    fallbackImage,
+    imageLoadingType,
+    containerStyles,
   } = {
     ...defaultProps,
-    ...props
+    ...props,
   }
 
   return (
-    <Column gap={5} onClick={onClick} styles={cssContainerStyles(containerStyles)}>
+    <Column
+      gap={5}
+      onClick={onClick}
+      styles={cssContainerStyles(containerStyles)}
+      itemProp="item"
+      itemScope
+      itemType="https://schema.org/Product"
+    >
       <Typography
-        type='helper'
+        type="helper"
         numberOfLines={1}
         weight={700}
         size={10}
         children={label}
+        itemProp="gtin13"
         styles={cssLabelStyles}
       />
 
       <Content>
-        <ImageContainer>
-          {!image
-            ? <Icon name='image' size={35} />
-            : <Image src={image} fit='cover' width={68} height={68} />
-          }
+        <ImageContainer itemProp="image" content={image}>
+          <Image
+            src={image}
+            fit="cover"
+            loading={imageLoadingType}
+            width="100%"
+            height="100%"
+            fallback={fallbackImage}
+            alt={name}
+          />
         </ImageContainer>
 
-        <Column align='space-between' gap={0} flex={1}>
+        <Column align="space-between" gap={0} flex={1}>
           <Column gap={0}>
             <Typography
-              type='title-4'
+              type="title-3"
               numberOfLines={1}
               weight={700}
               size={16}
               children={name}
+              itemProp="name"
               styles={cssTitleStyles}
             />
             <Typography
-              type='description'
+              type="description"
               numberOfLines={2}
               size={12}
+              itemProp="description"
               children={description}
               styles={cssDescriptionStyles}
             />
           </Column>
 
-          {customSpecComponent
-            ? React.cloneElement(customSpecComponent)
-            : (
-              <Row gap={0} align='space-between'>
-                {specs?.map(({ key, value }) => (
-                  <Typography
-                    key={`${key}-${value}`}
-                    type='description'
-                    children={value}
-                    weight={700}
-                    size={14}
-                    styles={cssSpecsStyles}
-                    afterStyles={{
-                      content: ` ${key ?? ''}`,
-                      size: 10,
-                      weight: 300,
-                    }}
-                  />
-                ))}
-              </Row>
-            )}
+          {customSpecComponent ? (
+            React.cloneElement(customSpecComponent)
+          ) : (
+            <Row gap={0} align="space-between">
+              {specs?.map(({ key, value }) => (
+                <Typography
+                  key={`${key}-${value}`}
+                  type="description"
+                  children={value}
+                  weight={700}
+                  size={14}
+                  styles={cssSpecsStyles}
+                  afterStyles={{
+                    content: ` ${key ?? ''}`,
+                    size: 10,
+                    weight: 300,
+                  }}
+                />
+              ))}
+            </Row>
+          )}
         </Column>
       </Content>
     </Column>
@@ -149,7 +171,7 @@ const cssSpecsStyles = css`
     font-size: 18px;
     line-height: 22px;
 
-     &::after {
+    &::after {
       font-size: 16px;
     }
   }
@@ -163,14 +185,24 @@ const ImageContainer = styled.figure`
   height: 70px;
   background-color: ${({ theme }) => theme.colors.NEUTRAL.SIDE};
   border-radius: 10px;
-  
+
   -moz-user-select: none;
   -webkit-user-select: none;
   user-select: none;
 
+  img[data-image-is-fallback='true'] {
+    width: 40px;
+    height: 40px;
+  }
+
   @media screen and (min-width: 768px) {
     width: 80px;
     height: 80px;
+
+    img[data-image-is-fallback='true'] {
+      width: 50px;
+      height: 50px;
+    }
   }
 `
 


### PR DESCRIPTION
## Changelog release: 

- Add _fallback image_ if initial _src_ fails in `Image`
- Update `Button.Link` to use _color_ as colors.MAIN.INFO
- Align `Input` _icon_ vertically and increase _line-height_ for title-2
- Add _itemProps_ and _Tag.Meta_ for `Column`, `Pricing` and `OrderItem`
- Add _titleProps_ and _descriptionProps_ in `Section`
- Align `Breadcrumbs` _links_ vertically
- Add _fallbackImage_ for prop drilling into `OrderItem` and `ImagesGallery`
- Refactor
  - `FlatList` to render list based on _wrapperTag_ and _itemWrapperTag_
  - `ImagesGallery` for better SEO structure.
- Add `useDatasets` hook to `Image` and `Typography`
- Add _navigate_ prop in `Breadcrumbs` for using prefer navigator handler
- Add _versioning guide_ for Readme.md
