### PR TITLE
v1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.35.0
+
+- Support rendering custom HTML tags in `Row` and `Column` by using _as_ prop
+- Add `isBrowser` support for `useGetWidthElementById` hook
+- Create `MemoizedWrapper` HOC and apply it into `FlatList`
+- Update `Collapsable` to render section tag HTML
+- Add _fallbackImage_ and _if-clause_ to render docs quantity In OrderSnapshot
+
 # 1.34.0
 
 - Create `SearchInput` molecule

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wicadu/arepa",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Free and open-source CSS framework that it called Arepa because who does not love one?",
   "author": "wicadu Developers <help@dev.wicadu.com>",
   "exports": {

--- a/src/hooks/useGetWidthElementById.ts
+++ b/src/hooks/useGetWidthElementById.ts
@@ -1,18 +1,17 @@
 import { useState, useEffect } from 'react'
+import { isBrowser } from '../utils'
 
-function useGetWidthElementById(elementId) {
+function useGetWidthElementById(elementId: string): number {
   const [width, setWidth] = useState<number>(0)
 
   useEffect(() => {
-    if (document?.readyState === 'complete') {
-      const el = document?.getElementById(elementId)
+    if (isBrowser() && document.readyState === 'complete') {
+      const el = document.getElementById(elementId)
       if (el) setWidth(el.offsetWidth)
     }
-  }, [document?.readyState])
+  }, [elementId])
 
   return width
 }
 
 export default useGetWidthElementById
-
-

--- a/src/ui/hocs/MemoizedWrapper.tsx
+++ b/src/ui/hocs/MemoizedWrapper.tsx
@@ -1,0 +1,11 @@
+import { memo, ReactElement } from 'react'
+
+interface Props {
+  children: ReactElement
+}
+
+const MemoizedWrapper = memo(({ children }: Props) => {
+  return children
+})
+
+export default MemoizedWrapper

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -41,6 +41,7 @@ import InfiniteScroll from './hocs/InfiniteScroll'
 import ThemeProvider from './hocs/ThemeProvider'
 import RefForwarding from './hocs/RefForwarding'
 import InputFeedback from './hocs/InputFeedback'
+import MemoizedWrapper from './hocs/MemoizedWrapper'
 
 import { useTheme } from '@emotion/react'
 
@@ -104,6 +105,7 @@ export {
   InfiniteScroll,
   RefForwarding,
   InputFeedback,
+  MemoizedWrapper,
 
   // Hooks
   useTheme,

--- a/src/ui/layout/Column.tsx
+++ b/src/ui/layout/Column.tsx
@@ -16,16 +16,19 @@ interface Props {
   itemScope?: boolean
   itemType?: string
   forwardedRef?: React.Ref<HTMLDivElement>
+  as?: keyof JSX.IntrinsicElements
 }
 
 const defaultProps: Partial<Props> = {
   children: null,
   gap: 0,
   className: '',
+  as: 'div',
 }
 
 function Column(props: Props) {
   const {
+    as,
     children,
     align,
     gap,
@@ -45,6 +48,7 @@ function Column(props: Props) {
   return (
     <Container
       ref={forwardedRef}
+      as={as}
       align={align}
       gap={gap}
       flex={flex}

--- a/src/ui/layout/Row.tsx
+++ b/src/ui/layout/Row.tsx
@@ -17,6 +17,7 @@ interface Props {
   itemType?: string
   className?: string
   forwardedRef?: React.Ref<HTMLDivElement>
+  as?: keyof JSX.IntrinsicElements
 }
 
 const defaultProps: Partial<Props> = {
@@ -24,11 +25,13 @@ const defaultProps: Partial<Props> = {
   gap: 0,
   styles: '',
   className: '',
+  as: '',
 }
 
 function Row(props: Props) {
   const {
     children,
+    as,
     align,
     gap,
     flex,
@@ -48,6 +51,7 @@ function Row(props: Props) {
   return (
     <Container
       align={align}
+      as={as}
       gap={gap}
       flex={flex}
       styles={styles}

--- a/src/ui/molecules/Collapsable.tsx
+++ b/src/ui/molecules/Collapsable.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
 import { css, SerializedStyles, useTheme } from '@emotion/react'
+import styled from '@emotion/styled'
 
 import Icon from '../atoms/Icon'
 import Column from '../layout/Column'
@@ -11,16 +12,20 @@ interface Props {
   header: React.ReactElement | React.ReactElement[] | undefined
   children: React.ReactElement | React.ReactElement[] | undefined
   containerStyles?: string | SerializedStyles
+  wrapperTag?: keyof JSX.IntrinsicElements | React.ElementType
+  className?: string
 }
 
 const defaultProps: Partial<Props> = {
-  value: false
+  value: false,
+  className: '',
+  wrapperTag: 'section',
 }
 
 function Collapsable(props: Props) {
-  const { value, header, children, containerStyles } = {
+  const { value, header, children, containerStyles, className, wrapperTag } = {
     ...defaultProps,
-    ...props
+    ...props,
   }
 
   const [isItCollapsed, setIsItCollapsed] = useState<boolean>(value)
@@ -34,8 +39,19 @@ function Collapsable(props: Props) {
   }, [value])
 
   return (
-    <Column align='center' gap={10} styles={containerStyles}>
-      <Row onClick={toggleIsItCollapsed} gap={0} styles={cssHeaderContainerStyles}>
+    <StyledWrapper
+      align="center"
+      gap={10}
+      styles={containerStyles}
+      className={className}
+      as={wrapperTag}
+    >
+      <Row
+        onClick={toggleIsItCollapsed}
+        gap={0}
+        styles={cssHeaderContainerStyles}
+        as="header"
+      >
         <Icon
           name={isItCollapsed ? 'arrow_drop_down' : 'arrow_right'}
           size={25}
@@ -45,9 +61,11 @@ function Collapsable(props: Props) {
       </Row>
 
       {isItCollapsed ? <Column gap={0}>{children}</Column> : null}
-    </Column>
+    </StyledWrapper>
   )
 }
+
+const StyledWrapper = styled(Column)``
 
 const cssHeaderContainerStyles = css`
   cursor: pointer;

--- a/src/ui/organisms/FlatList/FlatList.tsx
+++ b/src/ui/organisms/FlatList/FlatList.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react'
+
 import styled from '@emotion/styled'
+import { SerializedStyles } from '@emotion/react'
 
 import InfiniteScroll from '../../hocs/InfiniteScroll'
 import FlatListSkeleton from './Skeleton'
-import { SerializedStyles } from '@emotion/react'
+import MemoizedWrapper from '../../hocs/MemoizedWrapper'
 
 type DataExtracted<ItemT> = (info: ItemT, index: number) => Partial<ItemT>
 
@@ -84,20 +86,22 @@ function FlatList<ItemT>(props: Props<ItemT>) {
             name={String(item?.[keyExtracted])}
             {...itemWrapperProps}
           >
-            {React.isValidElement(Component) ? (
-              React.cloneElement(
-                Component,
-                dataExtractor?.({ ...item }, index),
-                index
-              )
-            ) : (
-              <Component
-                {...dataExtractor?.({ ...item }, index)}
-                index={index}
-              />
-            )}
+            <MemoizedWrapper>
+              {React.isValidElement(Component) ? (
+                React.cloneElement(
+                  Component,
+                  dataExtractor?.({ ...item }, index),
+                  index
+                )
+              ) : (
+                <Component
+                  {...dataExtractor?.({ ...item }, index)}
+                  index={index}
+                />
+              )}
 
-            <meta itemProp="position" content={index} />
+              <meta itemProp="position" content={index} />
+            </MemoizedWrapper>
           </ItemWrapper>
         ))}
       </ListWrapper>

--- a/src/ui/organisms/OrderSnapshot.tsx
+++ b/src/ui/organisms/OrderSnapshot.tsx
@@ -39,11 +39,12 @@ interface Props {
   date: string
   status: string
   docs: string[]
-  totalOfDocs: number,
+  totalOfDocs: number
   price: PriceProps
   totalOfItems: number
   items: string[]
   users: string[]
+  fallbackImage: string
   alert?: AlertProps
   onClick: () => void
 }
@@ -59,32 +60,36 @@ function OrderSnapshot({
   items,
   users,
   totalOfItems,
-  onClick
+  fallbackImage,
+  onClick,
 }: Props) {
   const { colors } = useTheme()
 
-  const statusAsAlert: boolean = useMemo(() => !!Object.values(alert || {})?.length, [
-    alert
-  ])
+  const statusAsAlert: boolean = useMemo(
+    () => !!Object.values(alert || {})?.length,
+    [alert]
+  )
 
-  const remainingTotalOfItems: number = useMemo(() => totalOfItems - items?.length, [
-    totalOfItems,
-    items?.length
-  ])
+  const remainingTotalOfItems: number = useMemo(
+    () => totalOfItems - items?.length,
+    [totalOfItems, items?.length]
+  )
 
   const doContainsDocs: boolean = useMemo(() => Boolean(docs?.length), [docs])
 
   return (
     <Column gap={10} onClick={onClick} styles={cssContainerStyles}>
-      <Alert
-        size={UIElementSizesEnum.Small}
-        type={alert?.type}
-        title={alert?.title}
-        description={alert?.description}
-        show={statusAsAlert}
-      />
+      {statusAsAlert && (
+        <Alert
+          size={UIElementSizesEnum.Small}
+          type={alert?.type}
+          title={alert?.title}
+          description={alert?.description}
+          show={statusAsAlert}
+        />
+      )}
 
-      <Row align='space-between' styles={cssHeaderStyles}>
+      <Row align="space-between" styles={cssHeaderStyles}>
         {!statusAsAlert ? (
           <StatusChip
             type={statusAsTypes[status]}
@@ -94,37 +99,33 @@ function OrderSnapshot({
             iconSize={15}
           />
         ) : (
-          <Typography weight={700} size={16}>{String(id)}</Typography>
+          <Typography weight={700} size={16} children={String(id)} />
         )}
 
         <Typography
-          type='description'
+          type="description"
           size={12}
           children={dateFormat(date, { language: 'es-CL', withHours: true })}
         />
       </Row>
 
-      <Row align='space-between'>
+      <Row align="space-between">
         <Row gap={10} styles={cssItemsStyles}>
           <Row gap={5}>
-            {items?.map((image, index) => image
-              ? <Image
-                src={image}
+            {items?.map((image, index) => (
+              <Image
+                src={image || ''}
+                alt={`Product image ${index}`}
+                fallback={fallbackImage}
                 key={index}
                 width={50}
                 height={50}
               />
-              : <Icon
-                name='image'
-                key={index}
-                size={50}
-                withBackground={0.65}
-              />
-            )}
+            ))}
           </Row>
 
           <TotalOfRemainingItems
-            type='description'
+            type="description"
             size={16}
             show={remainingTotalOfItems > 0}
             children={`+${remainingTotalOfItems}`}
@@ -132,22 +133,20 @@ function OrderSnapshot({
         </Row>
 
         <UsersContainer>
-          {users?.map((image, index) => image
-            ? <ImageContainer position={index} key={index}>
-              <Image
-                src={image}
-                width={35}
-                height={35}
-                rounded={100}
+          {users?.map((image, index) =>
+            image ? (
+              <ImageContainer position={index} key={index}>
+                <Image src={image} width={35} height={35} rounded={100} />
+              </ImageContainer>
+            ) : (
+              <DefaultProfileImage
+                name="person"
+                key={index}
+                size={15}
+                color="white"
+                position={index}
               />
-            </ImageContainer>
-            : <DefaultProfileImage
-              name='person'
-              key={index}
-              size={15}
-              color='white'
-              position={index}
-            />
+            )
           )}
         </UsersContainer>
       </Row>
@@ -160,10 +159,12 @@ function OrderSnapshot({
         {doContainsDocs && (
           <Column gap={5}>
             <Typography
-              type='helper'
+              type="helper"
               weight={700}
               size={12}
-              children={`Documentos adicionales (${totalOfDocs})`}
+              children={`Documentos adicionales ${
+                Boolean(totalOfDocs) ? `(${totalOfDocs})` : ''
+              }`}
             />
 
             <Typography numberOfLines={1} children={docs} size={15} />
@@ -172,11 +173,11 @@ function OrderSnapshot({
 
         <Column gap={5}>
           <Typography
-            type='helper'
+            type="helper"
             weight={700}
             size={12}
-            align='right'
-            children='Total'
+            align="right"
+            children="Total"
           />
           <Pricing
             weight={700}
@@ -184,7 +185,7 @@ function OrderSnapshot({
             currencyCode={price?.currencyCode}
             currencySize={10}
             amount={price?.amount}
-            align='right'
+            align="right"
           />
         </Column>
       </Row>
@@ -193,7 +194,7 @@ function OrderSnapshot({
 }
 
 const cssContainerStyles = css`
-  cursor: pointer
+  cursor: pointer;
 `
 
 const cssHeaderStyles = css`
@@ -203,10 +204,10 @@ const cssHeaderStyles = css`
       padding: 4px;
     }
 
-    p[type="default"] {
+    p[type='default'] {
       font-size: 22px !important;
     }
-    p[type="description"] {
+    p[type='description'] {
       font-size: 18px !important;
     }
   }
@@ -217,7 +218,8 @@ const cssItemsStyles = css`
     gap: 15px;
     padding-top: 5px;
 
-    span.material-icons, p[type="description"] {
+    span.material-icons,
+    p[type='description'] {
       font-size: 18px;
       width: 65px;
       height: 65px;
@@ -259,12 +261,12 @@ const userProfileStyles = (position: number) => css`
   }
 `
 
-const ImageContainer = styled.figure <{ position: number }>`
+const ImageContainer = styled.figure<{ position: number }>`
   position: absolute;
   ${({ position }) => userProfileStyles(position)}
 `
 
-const DefaultProfileImage = styled(Icon) <{ position: number }>`
+const DefaultProfileImage = styled(Icon)<{ position: number }>`
   background-color: ${({ theme }) => theme.colors.FONT.HELPER};
   width: 35px;
   height: 35px;
@@ -278,7 +280,7 @@ const DefaultProfileImage = styled(Icon) <{ position: number }>`
   ${({ position }) => userProfileStyles(position)}
 `
 
-const TotalOfRemainingItems = styled(Typography) <{ show: boolean }>`
+const TotalOfRemainingItems = styled(Typography)<{ show: boolean }>`
   width: 45px;
   height: 45px;
   border-radius: 7px;
@@ -292,15 +294,15 @@ const TotalOfRemainingItems = styled(Typography) <{ show: boolean }>`
 
 const cssBottomStyles = css`
   @media screen and (min-width: 768px) {
-    p[type="helper"] {
+    p[type='helper'] {
       font-size: 16px;
     }
 
-    div:first-of-type > p[type="default"] {
+    div:first-of-type > p[type='default'] {
       font-size: 18px !important;
     }
 
-    div:last-of-type > p[type="default"] {
+    div:last-of-type > p[type='default'] {
       font-size: 22px !important;
 
       &::after {
@@ -309,6 +311,5 @@ const cssBottomStyles = css`
     }
   }
 `
-
 
 export default OrderSnapshot


### PR DESCRIPTION
- Support rendering custom HTML tags in `Row` and `Column` by using _as_ prop
- Add `isBrowser` support for `useGetWidthElementById` hook
- Create `MemoizedWrapper` HOC and apply it into `FlatList`
- Update `Collapsable` to render section tag HTML
- Add _fallbackImage_ and _if-clause_ to render docs quantity In OrderSnapshot
