### PR TITLE
v1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.38.0
+
+- Added `.getDateDifference()` to `chronos` to get difference between two dates in the specified granularity
+- Added `.getHour()` to `chronos` to format hours of a given date based on the options
+- Added `.getDay()` to `chronos` to format days of a given date based on the options
+- Added `.getMinute()` to `chronos` to format minutes of a given date based on the options
+- Added `.getWeek()` to `chronos` to format weeks of a given date based on the options
+- Added `.getMonth` to `chronos` to format months of a given date based on the options
+- Added _className_ prop in `StatusChip` and fixed color _styles_ in `Tabs`
+- Refactored `Checkbox.Group` and `Checkbox.Controller` for better _error handling_
+
 # 1.37.4
 
 - Added _defaultValue_ prop alongside defining _defaultProps_ in `Tabs`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wicadu/arepa",
-  "version": "1.37.4",
+  "version": "1.38.0",
   "description": "Free and open-source CSS framework that it called Arepa because who does not love one?",
   "author": "wicadu Developers <help@dev.wicadu.com>",
   "exports": {

--- a/src/ui/hocs/CheckboxController.tsx
+++ b/src/ui/hocs/CheckboxController.tsx
@@ -11,31 +11,28 @@ const { useForm } = Form
 
 const propTypes = {
   children: PropTypes.element.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   index: PropTypes.number.isRequired,
   value: PropTypes.string,
   checked: PropTypes.bool,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 }
 
 type Props = InferProps<typeof propTypes>
 
-function CheckboxController({
-  children,
-  name,
-  index,
-  ...props
-}: Props) {
+function CheckboxController({ children, name, index, ...props }: Props) {
   const { control } = useForm()
 
   return (
     <Container>
-      <VirtualInputs fields={[
-        {
-          name: `${name}.${index}.value`,
-          defaultValue: props.value,
-        }
-      ]} />
+      <VirtualInputs
+        fields={[
+          {
+            name: `${name}.${index}.value`,
+            defaultValue: props.value,
+          },
+        ]}
+      />
       <Controller
         name={`${name}.${index}.checked`}
         control={control}
@@ -61,7 +58,7 @@ function CheckboxController({
 const Container = styled.div``
 
 const ItemWrapper = styled.div`
-  width: 100%
+  width: 100%;
 `
 
 CheckboxController.propTypes = propTypes

--- a/src/ui/hocs/CheckboxGroup.tsx
+++ b/src/ui/hocs/CheckboxGroup.tsx
@@ -6,8 +6,6 @@ import styled from '@emotion/styled'
 
 import { getObjectField } from '../../utils'
 
-const { useForm } = Form
-
 interface Props {
   children: React.ReactNode
   name: string
@@ -26,9 +24,10 @@ function CheckboxGroup(props: Props) {
     ...props,
   }
 
-  const { formState } = useForm()
+  const { formState } = Form.useForm()
 
   const fieldError = getObjectField(formState?.errors, name)
+  const flatChildren = React.Children.toArray(children).flat()
 
   return (
     <Container>
@@ -38,11 +37,14 @@ function CheckboxGroup(props: Props) {
         hasError={Boolean(fieldError?.message)}
         name={name}
       >
-        {children.map((child) =>
-          React.cloneElement(child, {
-            name,
-            ...restOfprops,
-          })
+        {flatChildren?.map((child: React.ReactElement, index: number) =>
+          React.isValidElement(child)
+            ? React.cloneElement(child, {
+                key: child.key || index,
+                name,
+                ...restOfprops,
+              })
+            : null
         )}
       </StyledInputFeedback>
     </Container>

--- a/src/ui/molecules/StatusChip.tsx
+++ b/src/ui/molecules/StatusChip.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react'
 
 import { SerializedStyles, useTheme } from '@emotion/react'
@@ -13,7 +12,7 @@ export enum Types {
   Success = 'success',
   Error = 'error',
   Info = 'info',
-  Warning = 'warning'
+  Warning = 'warning',
 }
 
 const _types = {
@@ -31,13 +30,15 @@ interface Props {
   iconSize?: number
   textStyles?: SerializedStyles | string
   containerStyles?: SerializedStyles | string
+  className?: string
 }
 
 const defaultProps: Partial<Props> = {
   type: Types.Info,
   textSize: 14,
   iconSize: 18,
-  textStyles: ''
+  textStyles: '',
+  className: '',
 }
 
 function StatusChip(props: Props) {
@@ -48,17 +49,22 @@ function StatusChip(props: Props) {
     textColor,
     textSize,
     iconSize,
-    textStyles
+    textStyles,
+    className,
   } = {
     ...defaultProps,
-    ...props
+    ...props,
   }
 
   const { colors } = useTheme()
 
   return (
-    <Row gap={5} styles={containerStyles}>
-      <CheckIcon name={_types?.[type?.toLowerCase()]} type={type} size={iconSize} />
+    <Row gap={5} className={className} styles={containerStyles}>
+      <CheckIcon
+        name={_types?.[type?.toLowerCase()]}
+        type={type}
+        size={iconSize}
+      />
 
       {text && (
         <Typography
@@ -77,7 +83,8 @@ function StatusChip(props: Props) {
 const CheckIcon = styled(Icon)`
   ${({ theme, type }) => {
     const mainColor =
-      theme.colors.MAIN?.[String(type).toUpperCase()] || theme?.colors.MAIN.PRIMARY
+      theme.colors.MAIN?.[String(type).toUpperCase()] ||
+      theme?.colors.MAIN.PRIMARY
 
     return `
       border-radius: 25px;

--- a/src/ui/molecules/Tabs.tsx
+++ b/src/ui/molecules/Tabs.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { SerializedStyles, useTheme } from '@emotion/react'
+import { hexToRGBA } from '../../utils'
 
 interface Props {
   headers: React.ReactElement[]
@@ -93,7 +94,9 @@ const HeaderTab = styled.li<{ isActive: boolean; isDisabledTab: boolean }>`
   height: 50px;
   border-bottom: 1px solid
     ${({ theme, isActive }) =>
-      isActive ? theme?.colors.MAIN.INFO : theme.colors?.NEUTRAL.TRANSPARENT};
+      isActive
+        ? theme?.colors.MAIN.INFO
+        : hexToRGBA(theme.colors.FONT.DESCRIPTION, 0.3)};
 
   ${({ isDisabledTab }) => {
     let styles = ``

--- a/src/utils/chronos/getDay.ts
+++ b/src/utils/chronos/getDay.ts
@@ -1,0 +1,69 @@
+import capitalize from '../capitalize'
+
+export interface DayOptions {
+  /**
+   * Format for the day representation.
+   * Use `DD MMM` for formats like "12 Sept" or `DD EEE` for formats like "12 Mon".
+   * Defaults to `DD MMM`.
+   */
+  format?: 'DD MMM' | 'DD EEE'
+
+  /**
+   * Locale for day and month names.
+   * Defaults to "es" (Spanish).
+   */
+  locale?: string
+
+  /**
+   * Whether to capitalize the first letter of day/month names.
+   * Defaults to `false`.
+   */
+  capitalize?: boolean
+}
+
+const defaultOptions: DayOptions = {
+  format: 'DD MMM',
+  locale: 'es',
+  capitalize: true,
+}
+
+/**
+ * Retrieves the formatted day component of a given date based on the specified options.
+ *
+ * @param {Time} date - The date to retrieve days from.
+ * @param {DayOptions} [options={}] - Options for configuring the day format.
+ * @returns {string} - The formatted day string (e.g., "12 Sept", "13 Tue").
+ *
+ * @example
+ * const day1 = getDay(new Date(), { format: 'DD MMM', locale: 'en' }) // e.g., "12 Sept"
+ * const day2 = getDay(new Date(), { format: 'DD EEE', locale: 'es' }) // e.g., "12 lun"
+ */
+function getDay(date: Date, options: DayOptions = {}): string {
+  const {
+    format,
+    locale,
+    capitalize: shouldCapitalize,
+  } = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  const day = date.getDate().toString().padStart(2, '0')
+  let month = date.toLocaleString(locale, { month: 'short' })
+  let weekday = date.toLocaleString(locale, { weekday: 'short' })
+
+  if (shouldCapitalize) {
+    month = capitalize(month)
+    weekday = capitalize(weekday)
+  }
+
+  if (format === 'DD MMM') {
+    return `${day} ${month}`
+  } else if (format === 'DD EEE') {
+    return `${day} ${weekday}`
+  }
+
+  throw new Error(`Unsupported format: ${format}`)
+}
+
+export default getDay

--- a/src/utils/chronos/getDiffBetweenDates.ts
+++ b/src/utils/chronos/getDiffBetweenDates.ts
@@ -1,0 +1,35 @@
+import toMilliseconds, { TimeType } from './toMilliseconds'
+
+/**
+ * Calculates the difference between two dates in the specified granularity (e.g., seconds, minutes, hours, days, months, years).
+ *
+ * @param {string | Date} start - The start date (ISO string or any format accepted by the Date constructor).
+ * @param {string | Date} end - The end date (ISO string or any format accepted by the Date constructor).
+ * @param {TimeType} granularity - The unit of measurement for the difference ('seconds', 'minutes', 'hours', 'days', 'months', 'years').
+ * @returns {number} The difference between the two dates in the specified granularity.
+ *
+ * @example
+ * // Get the difference in days
+ * getDateDifference('2024-01-01', '2025-01-01', 'days') // Returns 365
+ *
+ * // Get the difference in hours
+ * getDateDifference('2024-01-01T00:00:00', '2024-01-02T00:00:00', 'hours') // Returns 24
+ */
+function getDateDifference(
+  start: Date | string,
+  end: Date | string,
+  granularity: TimeType
+): number {
+  const startDate: Date = new Date(start)
+  const endDate: Date = new Date(end)
+
+  const differenceInMilliseconds: number =
+    endDate.getTime() - startDate.getTime()
+
+  const differenceInRequestedGranularity: number =
+    differenceInMilliseconds / toMilliseconds(1, granularity)
+
+  return differenceInRequestedGranularity
+}
+
+export default getDateDifference

--- a/src/utils/chronos/getHour.ts
+++ b/src/utils/chronos/getHour.ts
@@ -1,6 +1,4 @@
-type Time = Date | string
-
-export interface HoursOptions {
+export interface HourOptions {
   /**
    * Whether to return the hour in 24-hour format.
    * Defaults to true for 24-hour format. Set to false for 12-hour format with AM/PM.
@@ -14,7 +12,7 @@ export interface HoursOptions {
   locale?: 'es' | 'en' | 'pt' | 'fr'
 }
 
-const defaultOptions: HoursOptions = {
+const defaultOptions: HourOptions = {
   is24HourFormat: false,
   locale: 'es',
 }
@@ -23,20 +21,23 @@ const defaultOptions: HoursOptions = {
  * Retrieves the hours component of a given date based on the specified options.
  *
  * @param {Time} date - The date to retrieve hours from.
- * @param {HoursOptions} [options=defaultOptions] - Options for configuring the hour format and locale.
+ * @param {HourOptions} [options=defaultOptions] - Options for configuring the hour format and locale.
  * @returns {string | number} - The hours (e.g., 23 for 11 PM in 24-hour format, or "11 PM" in 12-hour format).
+ *
+ * @example
+ * const hours24 = getHour(new Date(), { is24HourFormat: true }) // e.g., 23
+ * const hours12 = getHour(new Date(), { is24HourFormat: false }) // e.g., 11PM
  */
-function getHours(
-  date: Time = new Date(),
-  options: HoursOptions = defaultOptions
+function getHour(
+  date: Date = new Date(),
+  options: HourOptions = defaultOptions
 ): string | number {
   const { is24HourFormat, locale } = {
     ...defaultOptions,
     ...options,
   }
 
-  const standardizedDate = new Date(date)
-  const hours = standardizedDate.getHours()
+  const hours = date.getHours()
 
   const amPmMap: Record<string, { am: string; pm: string }> = {
     en: { am: 'AM', pm: 'PM' },
@@ -53,4 +54,4 @@ function getHours(
   return `${hour12}${period}`
 }
 
-export default getHours
+export default getHour

--- a/src/utils/chronos/getHours.ts
+++ b/src/utils/chronos/getHours.ts
@@ -1,0 +1,56 @@
+type Time = Date | string
+
+export interface HoursOptions {
+  /**
+   * Whether to return the hour in 24-hour format.
+   * Defaults to true for 24-hour format. Set to false for 12-hour format with AM/PM.
+   */
+  is24HourFormat?: boolean
+
+  /**
+   * The locale to format the AM/PM in the appropriate language (e.g., 'en' for English, 'es' for Spanish).
+   * Defaults to 'es' (Spanish).
+   */
+  locale?: 'es' | 'en' | 'pt' | 'fr'
+}
+
+const defaultOptions: HoursOptions = {
+  is24HourFormat: false,
+  locale: 'es',
+}
+
+/**
+ * Retrieves the hours component of a given date based on the specified options.
+ *
+ * @param {Time} date - The date to retrieve hours from.
+ * @param {HoursOptions} [options=defaultOptions] - Options for configuring the hour format and locale.
+ * @returns {string | number} - The hours (e.g., 23 for 11 PM in 24-hour format, or "11 PM" in 12-hour format).
+ */
+function getHours(
+  date: Time = new Date(),
+  options: HoursOptions = defaultOptions
+): string | number {
+  const { is24HourFormat, locale } = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  const standardizedDate = new Date(date)
+  const hours = standardizedDate.getHours()
+
+  const amPmMap: Record<string, { am: string; pm: string }> = {
+    en: { am: 'AM', pm: 'PM' },
+    es: { am: 'am', pm: 'pm' },
+    fr: { am: 'AM', pm: 'PM' },
+  }
+
+  if (is24HourFormat) return hours
+
+  const period =
+    hours >= 12 ? amPmMap[locale]?.pm || 'PM' : amPmMap[locale]?.am || 'AM'
+
+  const hour12 = hours % 12 || 12
+  return `${hour12}${period}`
+}
+
+export default getHours

--- a/src/utils/chronos/getMinute.ts
+++ b/src/utils/chronos/getMinute.ts
@@ -1,0 +1,35 @@
+export interface MinuteOptions {
+  /**
+   * Whether to pad the minutes with a leading zero if less than 10.
+   * Defaults to true.
+   */
+  padWithZero?: boolean
+}
+
+const defaultOptions: MinuteOptions = {
+  padWithZero: true,
+}
+
+/**
+ * Retrieves the minutes component of a given date, formatted based on the specified options.
+ *
+ * @param {Time} date - The date to retrieve minutes from.
+ * @param {MinuteOptions} [options=defaultOptions] - Options for configuring the minute format.
+ * @returns {string | number} - The minutes (e.g., "01", "02" for padded, or 1, 2 for unpadded).
+ *
+ * @example
+ * const minutesPadded = getMinute(new Date(), { padWithZero: true }) // e.g., "03"
+ * const minutesUnpadded = getMinute(new Date(), { padWithZero: false }) // e.g., 3
+ */
+function getMinute(date: Date, options: MinuteOptions = {}): string {
+  const { padWithZero } = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  const minutes = date.getMinutes()
+
+  return padWithZero ? minutes.toString().padStart(2, '0') : minutes.toString()
+}
+
+export default getMinute

--- a/src/utils/chronos/getMonth.ts
+++ b/src/utils/chronos/getMonth.ts
@@ -1,0 +1,71 @@
+import capitalize from '../capitalize'
+
+export interface MonthOptions {
+  /**
+   * Format for the month representation.
+   * Use `MMM` for formats like "Jun", "Ago", "Sept", "Dec",
+   * `MMMM` for full month names like "January", "August", "December",
+   * or `M` for the numeric month (e.g., "1", "8", etc.).
+   * Defaults to `MMM`.
+   */
+  format?: 'MMM' | 'MMMM' | 'M'
+
+  /**
+   * Locale for month names.
+   * Defaults to "es" (Spanish).
+   */
+  locale?: string
+
+  /**
+   * Whether to capitalize the first letter of the month name.
+   * Defaults to `true`.
+   */
+  capitalize?: boolean
+}
+
+const defaultMonthOptions: MonthOptions = {
+  format: 'MMM',
+  locale: 'es',
+  capitalize: true,
+}
+
+/**
+ * Retrieves the formatted month component of a given date based on the specified options.
+ *
+ * @param {Date} date - The date to retrieve the month from.
+ * @param {MonthOptions} [options={}] - Options for configuring the month format.
+ * @returns {string} - The formatted month string (e.g., "Jun", "December", "8").
+ *
+ * @example
+ * const month1 = getMonth(new Date(), { format: 'MMM', locale: 'en' }) // e.g., "Jun"
+ * const month2 = getMonth(new Date(), { format: 'MMMM', locale: 'es' }) // e.g., "Enero"
+ * const month3 = getMonth(new Date(), { format: 'M' }) // e.g., "8" for August
+ */
+function getMonth(date: Date, options: MonthOptions = {}): string {
+  const {
+    format,
+    locale,
+    capitalize: shouldCapitalize,
+  } = {
+    ...defaultMonthOptions,
+    ...options,
+  }
+
+  let month: string
+
+  if (format === 'M') {
+    month = (date.getMonth() + 1).toString() // Get month number
+  } else {
+    month = date.toLocaleString(locale, {
+      month: format === 'MMM' ? 'short' : 'long',
+    })
+  }
+
+  if (shouldCapitalize && format !== 'M') {
+    month = capitalize(month)
+  }
+
+  return month
+}
+
+export default getMonth

--- a/src/utils/chronos/getWeek.ts
+++ b/src/utils/chronos/getWeek.ts
@@ -1,0 +1,114 @@
+import capitalize from '../capitalize'
+
+export interface WeekOptions {
+  /**
+   * Format for the week representation.
+   * - `W`: Short week of the month (e.g., "1W").
+   * - `WWW`: Full week of the month (e.g., "Semana 1", "Week 1").
+   * - `YW`: Short week of the year (e.g., "27W").
+   * - `YWWW`: Full week of the year (e.g., "Semana 27", "Week 27").
+   */
+  format?: 'W' | 'WWW' | 'YW' | 'YWWW'
+
+  /**
+   * Locale for week labels.
+   * Defaults to "es" (Spanish).
+   */
+  locale?: string
+
+  /**
+   * Whether to capitalize the first letter of week labels.
+   * Defaults to `false`.
+   */
+  capitalize?: boolean
+}
+
+const defaultOptions: WeekOptions = {
+  format: 'W',
+  locale: 'es',
+  capitalize: true,
+}
+
+/**
+ * Determines the week of the month for a given date.
+ */
+function getWeekOfMonth(date: Date): number {
+  const firstDayOfMonth = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    1
+  ).getDay()
+  return Math.ceil((date.getDate() + firstDayOfMonth) / 7)
+}
+
+/**
+ * Determines the week of the year for a given date.
+ */
+function getWeekOfYear(date: Date): number {
+  const startOfYear = new Date(date.getFullYear(), 0, 1)
+  const pastDays = Math.floor(
+    (date.getTime() - startOfYear.getTime()) / (1000 * 60 * 60 * 24)
+  )
+  return Math.ceil((pastDays + startOfYear.getDay() + 1) / 7)
+}
+
+/**
+ * Formats weeks based on the specified options.
+ */
+function getWeek(date: Date, options: WeekOptions = {}): string {
+  const {
+    format,
+    locale,
+    capitalize: shouldCapitalize,
+  } = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  const localeMap = {
+    es: {
+      W: 's',
+      YW: 's',
+      WWW: 'semana',
+      YWWW: 'semana',
+    },
+    en: {
+      W: 'w',
+      YW: 'w',
+      WWW: 'week',
+      YWWW: 'week',
+    },
+  }
+
+  let label = localeMap[locale][format]
+
+  if (shouldCapitalize) {
+    label = capitalize(localeMap[locale][format])
+  }
+
+  const weekOfMonth = getWeekOfMonth(date)
+  const weekOfYear = getWeekOfYear(date)
+
+  let week = ''
+
+  switch (format) {
+    case 'W':
+      week = `${label}${weekOfMonth}`
+      break
+    case 'WWW':
+      week = `${label} ${weekOfMonth}`
+      break
+    case 'YW':
+      week = `${label}${weekOfYear}`
+      break
+    case 'YWWW':
+      week = `${label} ${weekOfYear}`
+      break
+    default:
+      throw new Error(`Unsupported format: ${format}`)
+  }
+
+  return shouldCapitalize ? capitalize(week) : week
+}
+
+export default getWeek

--- a/src/utils/chronos/index.ts
+++ b/src/utils/chronos/index.ts
@@ -1,12 +1,15 @@
-import dateFormat from './dateFormat'
-import type { DateFormatOptions } from './dateFormat'
-import toMilliseconds, { TimeType } from './toMilliseconds'
+import getDateDifference from './getDiffBetweenDates'
+import dateFormat, { type DateFormatOptions } from './dateFormat'
+import getHours, { type HoursOptions } from './getHours'
+import toMilliseconds, { type TimeType } from './toMilliseconds'
+
+export type Time = Date | string
 
 /**
  * `chronos` is a versatile date utility that wraps around `dateFormat`.
  * It provides both a default formatted date string and methods for extracting specific date and time components.
  *
- * @param {Date | string} [date=new Date()] - The date to format. Defaults to the current date.
+ * @param {Time} [date=new Date()] - The date to format. Defaults to the current date.
  * @returns {string | Object} - The formatted date string or an object with methods for specific date components.
  *
  * @example
@@ -22,7 +25,7 @@ import toMilliseconds, { TimeType } from './toMilliseconds'
  * // Use in template literals or concatenation
  * console.log(`Date: ${chrono}`) // "Date: 25 de diciembre de 2024 11:59 PM"
  */
-function chronos(date: Date | string = new Date()) {
+function chronos(date: Time = new Date()) {
   const standardizedDate = new Date(date)
 
   // Instance methods to access specific date components
@@ -54,10 +57,11 @@ function chronos(date: Date | string = new Date()) {
     day: () => standardizedDate.getDate(),
 
     /**
-     * Retrieves the hours component of the time (24-hour format).
-     * @returns {number} - The hours (e.g., 23 for 11 PM).
+     * Retrieves the hours component of the time based on the specified options.
+     * @param {HoursOptions} [options={}] - Options for configuring the hour format.
+     * @returns {string | number} - The hours (e.g., 23 for 11 PM in 24-hour format, or "11 PM" in 12-hour format).
      */
-    hour: () => standardizedDate.getHours(),
+    hour: (options: HoursOptions = {}) => getHours(standardizedDate, options),
 
     /**
      * Retrieves the minutes component of the time.
@@ -71,7 +75,7 @@ function chronos(date: Date | string = new Date()) {
      * @example
      * { date: "25 de diciembre de 2024", time: "11:59 PM" }
      */
-    getTimeComponents: (options: Partial<DateFormatOptions>) => {
+    getTime: (options: Partial<DateFormatOptions>) => {
       const timeOptions: Partial<DateFormatOptions> = {
         withHours: true,
         ...options,
@@ -82,8 +86,8 @@ function chronos(date: Date | string = new Date()) {
         formattedTime.split(/(\d{1,2}:\d{2} [APM]{2})/).filter(Boolean) || []
 
       return {
-        date: dateTime?.trim(),
-        time: hoursTime?.trim(),
+        dateTime: dateTime?.trim(),
+        hoursTime: hoursTime?.trim(),
       }
     },
 
@@ -98,6 +102,18 @@ function chronos(date: Date | string = new Date()) {
     subtract: (value: number, type: TimeType): Date => {
       const timeToSSubtract: number = toMilliseconds(value, type)
       return new Date(standardizedDate.getTime() - timeToSSubtract)
+    },
+
+    /**
+     * Returns the difference in granularity (e.g., seconds, minutes, hours, days) between the current date and another date.
+     * @param {Time} end - The end date to compare with.
+     * @param {TimeType} granularity - The unit of time for the difference ('seconds', 'minutes', 'hours', 'days', 'months', 'years').
+     * @returns {number} - The difference between the two dates in the specified granularity.
+     * @example
+     * const diffInDays = chronos().diff('2025-01-01', 'days')
+     */
+    diff: (end: Time, granularity: TimeType): number => {
+      return getDateDifference(standardizedDate, end, granularity)
     },
   }
 

--- a/src/utils/chronos/index.ts
+++ b/src/utils/chronos/index.ts
@@ -1,7 +1,13 @@
+import toMilliseconds, { type TimeType } from './toMilliseconds'
+
 import getDateDifference from './getDiffBetweenDates'
 import dateFormat, { type DateFormatOptions } from './dateFormat'
-import getHours, { type HoursOptions } from './getHours'
-import toMilliseconds, { type TimeType } from './toMilliseconds'
+
+import getMinute, { MinuteOptions } from './getMinute'
+import getHour, { HourOptions } from './getHour'
+import getDay, { DayOptions } from './getDay'
+import getWeek, { WeekOptions } from './getWeek'
+import getMonth, { MonthOptions } from './getMonth'
 
 export type Time = Date | string
 
@@ -26,7 +32,9 @@ export type Time = Date | string
  * console.log(`Date: ${chrono}`) // "Date: 25 de diciembre de 2024 11:59 PM"
  */
 function chronos(date: Time = new Date()) {
-  const standardizedDate = new Date(date)
+  const localeDate = new Date(date)
+  const timezoneOffset = localeDate.getTimezoneOffset() * 60000
+  const standardizedDate = new Date(localeDate.getTime() + timezoneOffset)
 
   // Instance methods to access specific date components
   const instance = {
@@ -48,26 +56,36 @@ function chronos(date: Time = new Date()) {
      * Retrieves the month component of the date (1-based, e.g., January = 1).
      * @returns {number} - The month (e.g., 12 for December).
      */
-    month: () => standardizedDate.getMonth() + 1,
+    month: (options: MonthOptions = {}) => getMonth(standardizedDate, options),
 
     /**
-     * Retrieves the day of the month.
-     * @returns {number} - The day of the month (e.g., 25).
+     * Retrieves the week day based on the specified options.
+     * @param {WeekOptions} [options={}] - Options for configuring the week format.
+     * @returns {string} - The formatted week string (e.g., "Mon", "Monday").
      */
-    day: () => standardizedDate.getDate(),
+    week: (options: WeekOptions = {}) => getWeek(standardizedDate, options),
+
+    /**
+     * Retrieves the formatted day component of the time based on the specified options.
+     * @param {DayOptions} [options={}] - Options for configuring the day format.
+     * @returns {string} - The formatted day string (e.g., "12 Sept", "13 Tue").
+     */
+    day: (options: DayOptions = {}) => getDay(standardizedDate, options),
 
     /**
      * Retrieves the hours component of the time based on the specified options.
-     * @param {HoursOptions} [options={}] - Options for configuring the hour format.
+     * @param {HourOptions} [options={}] - Options for configuring the hour format.
      * @returns {string | number} - The hours (e.g., 23 for 11 PM in 24-hour format, or "11 PM" in 12-hour format).
      */
-    hour: (options: HoursOptions = {}) => getHours(standardizedDate, options),
+    hour: (options: HourOptions = {}) => getHour(standardizedDate, options),
 
     /**
-     * Retrieves the minutes component of the time.
-     * @returns {number} - The minutes (e.g., 59).
+     * Retrieves the minutes component of the time based on the specified options.
+     * @param {MinuteOptions} [options={}] - Options for configuring the minute format.
+     * @returns {string | number} - The minutes (e.g., "01", "02" for padded, or 1, 2 for unpadded).
      */
-    minute: () => standardizedDate.getMinutes(),
+    minute: (options: MinuteOptions = {}) =>
+      getMinute(standardizedDate, options),
 
     /**
      * Retrieves date and time components as an object with `date` and `time` properties.


### PR DESCRIPTION
- Added `.getDateDifference()` to `chronos` to get difference between two dates in the specified granularity
- Added `.getHour()` to `chronos` to format hours of a given date based on the options
- Added `.getDay()` to `chronos` to format days of a given date based on the options
- Added `.getMinute()` to `chronos` to format minutes of a given date based on the options
- Added `.getWeek()` to `chronos` to format weeks of a given date based on the options
- Added `.getMonth` to `chronos` to format months of a given date based on the options
- Added _className_ prop in `StatusChip` and fixed color _styles_ in `Tabs`
- Refactored `Checkbox.Group` and `Checkbox.Controller` for better _error handling_